### PR TITLE
Add Traefik ingress to Zachbot Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Zachbot is a Go web service that proxies requests to an [Ollama](https://github.
 
 1. Start an Ollama instance or forward the service if it runs in a cluster:
    ```sh
-   kubectl -n ollama port-forward service/ollama 11434:80
+   kubectl port-forward service/zachbot-zachbot-ollama 11434:80
    ```
 2. Build and run the web application:
    ```sh
@@ -56,6 +56,12 @@ helm install zachbot k8s/helm/zachbot \
   --set zachbot.image.repository=myrepo/zachbot \
   --set ollama.image.repository=myrepo/ollama
 ```
+
+The chart also provisions Traefik ingresses for both services. By default,
+Zachbot is available at `http://zachbot.localhost` and the Ollama API at
+`http://ollama.localhost`. These hosts correspond to the
+`zachbot.ingress.host` and `ollama.ingress.host` entries in `values.yaml` and
+may be overridden as needed.
 
 ## Project structure
 

--- a/k8s/helm/zachbot/templates/ollama-ingress.yaml
+++ b/k8s/helm/zachbot/templates/ollama-ingress.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.ollama.enabled .Values.ollama.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "zachbot.fullname" . }}-ollama
+  {{- with .Values.ollama.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ollama.ingress.className }}
+  rules:
+    - host: {{ .Values.ollama.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ollama.ingress.path }}
+            pathType: {{ .Values.ollama.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "zachbot.fullname" . }}-ollama
+                port:
+                  number: {{ .Values.ollama.service.port }}
+{{- end }}

--- a/k8s/helm/zachbot/templates/zachbot-ingress.yaml
+++ b/k8s/helm/zachbot/templates/zachbot-ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.zachbot.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "zachbot.fullname" . }}
+  {{- with .Values.zachbot.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.zachbot.ingress.className }}
+  rules:
+    - host: {{ .Values.zachbot.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.zachbot.ingress.path }}
+            pathType: {{ .Values.zachbot.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "zachbot.fullname" . }}
+                port:
+                  number: {{ .Values.zachbot.service.port }}
+{{- end }}

--- a/k8s/helm/zachbot/values.yaml
+++ b/k8s/helm/zachbot/values.yaml
@@ -7,6 +7,13 @@ zachbot:
   service:
     type: ClusterIP
     port: 80
+  ingress:
+    enabled: true
+    className: traefik
+    host: zachbot.localhost
+    path: /
+    pathType: Prefix
+    annotations: {}
   env:
     OLLAMA_HOST: ollama
     OLLAMA_PORT: "80"
@@ -28,6 +35,13 @@ ollama:
   service:
     type: ClusterIP
     port: 80
+  ingress:
+    enabled: true
+    className: traefik
+    host: ollama.localhost
+    path: /
+    pathType: Prefix
+    annotations: {}
   nodeAffinity:
     key: node-role.kubernetes.io/control-plane
     operator: NotIn


### PR DESCRIPTION
## Summary
- expose Zachbot and Ollama via Traefik ingresses
- document default ingress hosts and update port-forward example

## Testing
- `helm lint k8s/helm/zachbot` *(fails: command not found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c202ee0478832698431fbe66591766